### PR TITLE
Windows support for rid link, build, clean and lint commands

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -14,8 +14,11 @@ const babelPlugins = [
 
 const babelCommand = (extension, extra) => {
     const additional = extra ? ` ${extra}` : '';
-    return `${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
+
+    var preFix = /^win/.test(process.platform) ? 'node ' : '';
+    return `${preFix}${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
         ` --source-maps --plugins ${babelPlugins}${additional}`;
+
 };
 
 module.exports = (extensions, extra) =>

--- a/commands/build.js
+++ b/commands/build.js
@@ -15,7 +15,7 @@ const babelPlugins = [
 const babelCommand = (extension, extra) => {
     const additional = extra ? ` ${extra}` : '';
 
-    let preFix = /^win/.test(process.platform) ? 'node ' : '';
+    const preFix = /^win/.test(process.platform) ? 'node ' : '';
     return `${preFix}${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
         ` --source-maps --plugins ${babelPlugins}${additional}`;
 };

--- a/commands/build.js
+++ b/commands/build.js
@@ -15,10 +15,9 @@ const babelPlugins = [
 const babelCommand = (extension, extra) => {
     const additional = extra ? ` ${extra}` : '';
 
-    var preFix = /^win/.test(process.platform) ? 'node ' : '';
+    let preFix = /^win/.test(process.platform) ? 'node ' : '';
     return `${preFix}${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
         ` --source-maps --plugins ${babelPlugins}${additional}`;
-
 };
 
 module.exports = (extensions, extra) =>

--- a/commands/build.js
+++ b/commands/build.js
@@ -14,9 +14,7 @@ const babelPlugins = [
 
 const babelCommand = (extension, extra) => {
     const additional = extra ? ` ${extra}` : '';
-
-    const preFix = /^win/.test(process.platform) ? 'node ' : '';
-    return `${preFix}${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
+    return `node ${babel} ${extension.path}/src --out-dir ${extension.path}/lib ` +
         ` --source-maps --plugins ${babelPlugins}${additional}`;
 };
 

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -1,9 +1,6 @@
 const rimraf = require.resolve('rimraf/bin');
 
-const clean = (extension) => {
-    const preFix = /^win/.test(process.platform) ? 'node ' : '';
-    return `${preFix}${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
-};
+const clean = (extension) => `node ${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
 
 module.exports = (extensions) =>
     extensions

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -1,7 +1,7 @@
 const rimraf = require.resolve('rimraf/bin');
 
 const clean = (extension) => {
-    let preFix = /^win/.test(process.platform) ? 'node ' : '';
+    const preFix = /^win/.test(process.platform) ? 'node ' : '';
     return `${preFix}${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
 };
 

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -1,6 +1,9 @@
 const rimraf = require.resolve('rimraf/bin');
 
-const clean = (extension) => `${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
+const clean = (extension) => {
+  var preFix = /^win/.test(process.platform) ? 'node ' : '';
+  return `${preFix}${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
+}
 
 module.exports = (extensions) =>
     extensions

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -1,9 +1,9 @@
 const rimraf = require.resolve('rimraf/bin');
 
 const clean = (extension) => {
-  var preFix = /^win/.test(process.platform) ? 'node ' : '';
-  return `${preFix}${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
-}
+    let preFix = /^win/.test(process.platform) ? 'node ' : '';
+    return `${preFix}${rimraf} ${extension.path}/lib ${extension.path}/esdocs`;
+};
 
 module.exports = (extensions) =>
     extensions

--- a/commands/link.js
+++ b/commands/link.js
@@ -18,7 +18,7 @@ const linkPrevious = (name, yarn) => {
 
 const linkExtra = (extra, yarn) => {
     if (extra.length === 0) {
-        let noop = /^win/.test(process.platform) ? 'echo \'\'' : ':';
+        let noop = /^win/.test(process.platform) ? 'echo.' : ':';
         // Noop in bash
         return noop;
     }

--- a/commands/link.js
+++ b/commands/link.js
@@ -18,9 +18,7 @@ const linkPrevious = (name, yarn) => {
 
 const linkExtra = (extra, yarn) => {
     if (extra.length === 0) {
-        let noop = /^win/.test(process.platform) ? 'echo.' : ':';
-        // Noop in bash
-        return noop;
+        return /^win/.test(process.platform) ? 'echo.' : ':';
     }
 
     const pkg = yarn ? 'yarn' : 'npm';

--- a/commands/link.js
+++ b/commands/link.js
@@ -18,18 +18,19 @@ const linkPrevious = (name, yarn) => {
 
 const linkExtra = (extra, yarn) => {
     if (extra.length === 0) {
-        return /^win/.test(process.platform) ? 'echo.' : ':';
+        return '';
     }
 
     const pkg = yarn ? 'yarn' : 'npm';
 
-    return extra
+    return ` && ${extra
       .map((dependency) => `${pkg} link ${dependency}`)
-      .join(' && ');
+      .join(' && ')
+    }`;
 };
 
 const link = (extension, extra, yarn) =>
-    `cd ${extension.path} && ${linkExtra(extra, yarn)} && ${linkPrevious(extension.name, yarn)}`;
+    `cd ${extension.path}${linkExtra(extra, yarn)} && ${linkPrevious(extension.name, yarn)}`;
 
 module.exports = (extensions) => (commandObject) => {
     const extra = commandObject.arguments.managed.modules || [];

--- a/commands/link.js
+++ b/commands/link.js
@@ -18,8 +18,9 @@ const linkPrevious = (name, yarn) => {
 
 const linkExtra = (extra, yarn) => {
     if (extra.length === 0) {
+        let noop = /^win/.test(process.platform) ? 'echo \'\'' : ':';
         // Noop in bash
-        return ':';
+        return noop;
     }
 
     const pkg = yarn ? 'yarn' : 'npm';

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -1,8 +1,10 @@
 const eslint = require.resolve('eslint/bin/eslint');
 const eslintConfig = require.resolve('../configuration/.eslintrc.js');
 
-const eslintCommand = (extension) =>
-    `${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
+const eslintCommand = (extension) => {
+    var preFix = /^win/.test(process.platform) ? 'node ' : '';
+    return `${preFix}${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
+}
 
 module.exports = (extensions) =>
     extensions

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -2,7 +2,7 @@ const eslint = require.resolve('eslint/bin/eslint');
 const eslintConfig = require.resolve('../configuration/.eslintrc.js');
 
 const eslintCommand = (extension) => {
-    let preFix = /^win/.test(process.platform) ? 'node ' : '';
+    const preFix = /^win/.test(process.platform) ? 'node ' : '';
     return `${preFix}${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
 };
 

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -2,9 +2,9 @@ const eslint = require.resolve('eslint/bin/eslint');
 const eslintConfig = require.resolve('../configuration/.eslintrc.js');
 
 const eslintCommand = (extension) => {
-    var preFix = /^win/.test(process.platform) ? 'node ' : '';
+    let preFix = /^win/.test(process.platform) ? 'node ' : '';
     return `${preFix}${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
-}
+};
 
 module.exports = (extensions) =>
     extensions

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -1,10 +1,8 @@
 const eslint = require.resolve('eslint/bin/eslint');
 const eslintConfig = require.resolve('../configuration/.eslintrc.js');
 
-const eslintCommand = (extension) => {
-    const preFix = /^win/.test(process.platform) ? 'node ' : '';
-    return `${preFix}${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
-};
+const eslintCommand = (extension) =>
+    `node ${eslint} --config ${eslintConfig} ${extension.path}/src --no-ignore`;
 
 module.exports = (extensions) =>
     extensions


### PR DESCRIPTION
The link, build, clean and lint commands do not work on windows.

Lint, build and clean is run from installed node modules, and as such on windows has to be prefixed with node to be ran directly.

For link, using `:` as noop is not supported when chaining commands on windows.
`(...) && : && (...)`outputs `':' is not recognized as an internal or external command, operable program or batch file`. Using `echo.` works as a noop, as it ouputs an empty line to console.

These changes have been tested on windows 8 and 10 using node v6.10.0 and v7.6.0. Windows detection performed according to [this stackoverflow answer](http://stackoverflow.com/questions/8683895/how-do-i-determine-the-current-operating-system-with-node-js) so I assume it should detect os correctly, changes are however not tested on linux and mac.