### PR TITLE
Add a command, for executing local tests in extension folders

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -66,6 +66,10 @@ module.exports = {
         command: require('./lint')(extensions),
         description: 'Runs lint',
     },
+    'test:alias': {
+        command: require('./testAlias')(extensions),
+        description: 'Runs local test inside packages',
+    },
     release: {
         command: require('./release')(extensions),
         description: 'Run release script',

--- a/commands/testAlias.js
+++ b/commands/testAlias.js
@@ -1,0 +1,6 @@
+const test = (extension) => `cd ${extension.path}/ && npm run test`;
+
+module.exports = (extensions) =>
+    extensions
+        .map(test)
+        .join(' && ');


### PR DESCRIPTION
This command will simplify the execution of unit tests in extension folders, much like the `lint:alias` command to for lint purposes.