### PR TITLE
Added detection of npm5 fixing rid link, using npm install over npm link

### DIFF
--- a/commands/link.js
+++ b/commands/link.js
@@ -1,14 +1,17 @@
+const semver = require('semver');
 const executeSyncExit = require('roc').executeSyncExit;
 
 const previous = [];
 
 // We will link all previous with the next one, this might not be needed but we do it
 // because it's easy and it does not really hurt in any way.
-const linkPrevious = (name, yarn) => {
+const linkPrevious = (extension, yarn, useInstall) => {
     const pkg = yarn ? 'yarn' : 'npm';
 
-    const links = previous.map((prev) => `${pkg} link ${prev}`);
-    previous.push(name);
+    const operation = useInstall ? 'install' : 'link';
+    const links = previous
+      .map(({ path, name }) => `${pkg} ${operation} ${useInstall ? path : name}`);
+    previous.push(extension);
     if (yarn) {
         links.push('yarn install');
     }
@@ -29,15 +32,25 @@ const linkExtra = (extra, yarn) => {
     }`;
 };
 
-const link = (extension, extra, yarn) =>
-    `cd ${extension.path}${linkExtra(extra, yarn)} && ${linkPrevious(extension.name, yarn)}`;
+const link = (extension, extra, yarn, useInstall) =>
+    `cd ${extension.path}${linkExtra(extra, yarn)} && ${linkPrevious(extension, yarn, useInstall)}`;
 
 module.exports = (extensions) => (commandObject) => {
     const extra = commandObject.arguments.managed.modules || [];
     const yarn = commandObject.options.managed.yarn;
+
+    // We want to use "npm install" over "npm link" when running with npm 5+
+    // This since the behaviour seems to have changed when using "link" and
+    // in general direct install seems to be the recommended way for monorepos
+    // We only want to do this when using npm, not when using yarn
+    const useInstall = semver.satisfies(
+        executeSyncExit('npm -v', { silent: true }),
+        '>=5'
+    ) && !yarn;
+
     executeSyncExit(
       extensions
-        .map((extension) => link(extension, extra, yarn))
+        .map((extension) => link(extension, extra, yarn, useInstall))
         .join(' && ')
     );
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "~1.14.0",
     "readline-sync": "~1.4.4",
     "rimraf": "~2.5.4",
-    "roc": "^1.0.0-rc.11"
+    "roc": "^1.0.0-rc.11",
+    "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
This is needed since something has changed in npm5 that makes link fail, probably a bug that will get addressed in the future.

Bug or not, this is the recommended way to work with monorepos in npm5 which basically is what we are doing here, so a good change anyhow.