### PR TITLE
Add missing callback when generating documentation

### DIFF
--- a/generate-documentation.js
+++ b/generate-documentation.js
@@ -16,4 +16,10 @@ fs.writeFile(
        undefined,
        'rid'
    )
-);
+, (error) => {
+    if (error) {
+        throw error;
+    }
+
+    console.log('The documentation has been updated.');
+});


### PR DESCRIPTION
This addresses a deprecation warning in newer version of Node.